### PR TITLE
Add enable, disable, and encrypt functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist-rugs/rug-function-travis/compare/0.6.1...HEAD
+[Unreleased]: https://github.com/atomist-rugs/rug-function-travis/compare/0.7.0...HEAD
+
+### Added
+
+-   New Rug functions: travis-encrypt, travis-enable-repo, travis-disable-repo
+
+### Changed
+
+-   Updated to rug 0.25.1
+
+## [0.7.0] - 2017-03-30
+
+[0.7.0]: https://github.com/atomist-rugs/rug-function-travis/compare/0.6.1...0.7.0
+
+Papa's got a brand new Rug release
+
+### Changed
+
+-   Update to rug 0.25.0
 
 ## [0.6.1] - 2017-03-30
 

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 Rug functions that hit the [Travis CI][travis-ci] API.  Currently
 contains the following Rug functions:
 
--   `RestartBuild(org, buildId, token)`
--   `BuildRug(owner, repo, version, teamId, gitRef, travisToken, mavenBaseUrl, mavenUser, mavenToken, userToken)`
+-   `restart-travis-build(org, buildId, token)`
+-   `travis-build-rug(owner, repo, version, teamId, gitRef, travisToken, mavenBaseUrl, mavenUser, mavenToken, token)`
+-   `travis-enable-repo(owner, repo, org, token)`
+-   `travis-disable-repo(owner, repo, org, token)`
+-   `travis-encrypt(owner, repo, org, content, token)`
 
 [travis-ci]: https://travis-ci.org/
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.atomist.rug</groupId>
     <artifactId>rug-functions-travis</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rug-functions-travis</name>
     <description>rug-functions-travis</description>
@@ -14,7 +14,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <rug.version>(0.25.0,0.26.0]</rug.version>
+        <rug.version>[0.25.1,0.26.0)</rug.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/resources/META-INF/services/com.atomist.rug.spi.RugFunction
+++ b/src/main/resources/META-INF/services/com.atomist.rug.spi.RugFunction
@@ -1,2 +1,4 @@
 com.atomist.rug.functions.travis.RestartBuild
 com.atomist.rug.functions.travis.BuildRug
+com.atomist.rug.functions.travis.RepoHook
+com.atomist.rug.functions.travis.Encrypt

--- a/src/main/scala/com/atomist/rug/functions/travis/Encrypt.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/Encrypt.scala
@@ -1,0 +1,98 @@
+package com.atomist.rug.functions.travis
+
+import java.io.StringReader
+import java.security.{KeyFactory, Security}
+import java.security.spec.X509EncodedKeySpec
+import java.util.Base64
+import javax.crypto.Cipher
+
+import com.atomist.rug.runtime.Rug
+import com.atomist.rug.spi.Handlers.Status
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse, StringBodyOption}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+import com.typesafe.scalalogging.LazyLogging
+import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openssl.PEMParser
+import org.springframework.http.HttpHeaders
+
+object Encrypt {
+
+  Security.addProvider(new BouncyCastleProvider)
+
+}
+
+/**
+  * Use Travis API to encrypt strings using the repository public key.
+  */
+class Encrypt  extends AnnotatedRugFunction
+  with Rug
+  with LazyLogging {
+
+  private val travisEndpoints = new RealTravisEndpoints
+
+  /**
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to enable
+    * @param org Travis CI ".com" or ".org" endpoint
+    * @param content content to encrypt
+    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @return
+    */
+  @RugFunction(name = "travis-encrypt", description = "Encrypts a value using Travis CI repo public key",
+    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
+  def encrypt(
+                @Parameter(name = "owner") owner: String,
+                @Parameter(name = "repo") repo: String,
+                @Parameter(name = "org") org: String,
+                @Parameter(name = "content") content: String,
+                @Secret(name = "user_token", path = "github://user_token?scopes=repos") token: String
+             ): FunctionResponse = {
+
+    val api: TravisAPIEndpoint = TravisAPIEndpoint.stringToTravisEndpoint(org)
+    val travisToken: String = travisEndpoints.postAuthGitHub(api, token)
+    val headers: HttpHeaders = TravisEndpoints.authHeaders(api, travisToken)
+    val repoSlug = s"$owner/$repo"
+    try {
+      val encryptedContent = encryptString(repoSlug, api, headers, content)
+      FunctionResponse(
+        Status.Success,
+        Option(s"Successfully encrypted content for $repoSlug"),
+        None,
+        StringBodyOption(encryptedContent)
+      )
+    }
+    catch {
+      case e: Exception =>
+        FunctionResponse(
+          Status.Failure,
+          Some(s"Failed to encrypt content for $repoSlug"),
+          None,
+          StringBodyOption(e.getMessage)
+        )
+    }
+  }
+
+  def encryptString(
+                     repoSlug: String,
+                     api: TravisAPIEndpoint,
+                     headers: HttpHeaders,
+                     content: String
+                   ): String = {
+
+    val key = travisEndpoints.getRepoKey(api, headers, repoSlug)
+
+    val parser = new PEMParser(new StringReader(key))
+    val ob = parser.readObject().asInstanceOf[SubjectPublicKeyInfo]
+
+    val pubKeySpec = new X509EncodedKeySpec(ob.getEncoded())
+    val keyFactory = KeyFactory.getInstance("RSA")
+    val publicKey = keyFactory.generatePublic(pubKeySpec)
+
+    val rsaCipher = Cipher.getInstance("RSA/ECB/PKCS1Padding")
+    rsaCipher.init(Cipher.ENCRYPT_MODE, publicKey)
+
+    Base64.getEncoder.encodeToString(rsaCipher.doFinal(content.getBytes()))
+  }
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
@@ -1,0 +1,98 @@
+package com.atomist.rug.functions.travis
+
+import java.util
+
+import com.atomist.rug.runtime.Rug
+import com.atomist.rug.spi.Handlers.Status
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse, StringBodyOption}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+import com.typesafe.scalalogging.LazyLogging
+import org.springframework.http.HttpHeaders
+
+/**
+  * Enable and disable repos in Travis CI.
+  */
+class RepoHook extends AnnotatedRugFunction
+  with Rug
+  with LazyLogging {
+
+  private val travisEndpoints = new RealTravisEndpoints
+
+  /**
+    * Enable Travis CI builds for a GitHub repository.
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to enable
+    * @param org Travis CI ".com" or ".org" endpoint
+    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @return
+    */
+  @RugFunction(name = "travis-enable-repo", description = "Enables Travis CI builds for a GitHub repository",
+    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
+  def enable(
+              @Parameter(name = "owner") owner: String,
+              @Parameter(name = "repo") repo: String,
+              @Parameter(name = "org") org: String,
+              @Secret(name = "github_token", path = "github://user_token?scopes=repos") token: String
+            ): FunctionResponse = {
+    val enableTravis = true
+    tryRepoEnabler(enableTravis, owner, repo, token, org)
+  }
+
+  /**
+    * Disable Travis CI builds for a GitHub repository.
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to disable
+    * @param org Travis CI ".com" or ".org" endpoint
+    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @return
+    */
+  @RugFunction(name = "travis-disable-repo", description = "Disables Travis CI builds for a GitHub repository",
+    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
+  def disable(
+               @Parameter(name = "owner") owner: String,
+               @Parameter(name = "repo") repo: String,
+               @Parameter(name = "org") org: String,
+               @Secret(name = "github_token", path = "github://user_token?scopes=repos") token: String
+             ): FunctionResponse = {
+    val disableTravis = false
+    tryRepoEnabler(disableTravis, owner, repo, token, org)
+  }
+
+  private def tryRepoEnabler(active: Boolean, owner: String, repo: String, githubToken: String, org: String): FunctionResponse = {
+    val repoSlug = s"$owner/$repo"
+    val activeString = if (active) "enable" else "disable"
+    try {
+      repoEnabler(active, repoSlug, githubToken, org)
+      FunctionResponse(Status.Success, Option(s"Successfully ${activeString}d Travis CI for $repoSlug"), None, None)
+    } catch {
+      case e: Exception =>
+        FunctionResponse(
+          Status.Failure,
+          Some(s"Failed to $activeString Travis CI for $repoSlug"),
+          None,
+          StringBodyOption(e.getMessage)
+        )
+    }
+  }
+
+  private[travis] def repoEnabler(active: Boolean, repoSlug: String, githubToken: String, org: String): Unit = {
+    val api: TravisAPIEndpoint = TravisAPIEndpoint.stringToTravisEndpoint(org)
+    val token: String = travisEndpoints.postAuthGitHub(api, githubToken)
+    val headers: HttpHeaders = TravisEndpoints.authHeaders(api, token)
+
+    travisEndpoints.postUsersSync(api, headers)
+
+    val id: Int = travisEndpoints.getRepo(api, headers, repoSlug)
+
+    val hook = new util.HashMap[String, Any]()
+    hook.put("id", id)
+    hook.put("active", active)
+    val body = new util.HashMap[String, Object]()
+    body.put("hook", hook)
+
+    travisEndpoints.putHook(api, headers, body)
+  }
+
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/TravisEndpoints.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/TravisEndpoints.scala
@@ -38,10 +38,10 @@ trait TravisEndpoints {
     *
     * @param endpoint org|com
     * @param headers standard Travis API headers
-    * @param repo repo slug, e.g., "owner/name"
+    * @param repoSlug repo slug, e.g., "owner/name"
     * @return Repo key
     */
-  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repo: String): String
+  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String
 
   /** Enable or disable CI for the repo.
     *
@@ -62,10 +62,10 @@ trait TravisEndpoints {
     *
     * @param endpoint org|com
     * @param headers standard Travis API headers
-    * @param repo repo slug, e.g., "owner/name"
+    * @param repoSlug repo slug, e.g., "owner/name"
     * @return unique repo identifier
     */
-  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repo: String): Int
+  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int
 
   /** Authenticate with Travis using GitHub token.
     *
@@ -89,9 +89,9 @@ trait TravisEndpoints {
     *
     * @param endpoint org|com
     * @param headers standard Travis API headers
-    * @param repo repo slug, e.g., "atomist-rugs/rug-editors"
+    * @param repoSlug repo slug, e.g., "atomist-rugs/rug-editors"
     */
-  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repo: String, message: String, envVars: Seq[String]): Unit
+  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String, message: String, envVars: Seq[String]): Unit
 }
 
 object TravisEndpoints {
@@ -126,11 +126,11 @@ class RealTravisEndpoints extends TravisEndpoints {
 
   private val restTemplate: RestTemplate = new RestTemplate()
 
-  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repo: String): String = {
+  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String = {
     val request = new RequestEntity[util.Map[String, Object]](
       headers,
       HttpMethod.GET,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repo/key")
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug/key")
     )
     val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
     responseEntity.getBody.get("key").asInstanceOf[String]
@@ -179,11 +179,11 @@ class RealTravisEndpoints extends TravisEndpoints {
     }
   }
 
-  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repo: String): Int = {
+  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int = {
     val request = new RequestEntity[util.Map[String, Object]](
       headers,
       HttpMethod.GET,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repo")
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug")
     )
     val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
     val repoObject: util.Map[String, Object] = responseEntity.getBody.get("repo").asInstanceOf[util.Map[String, Object]]


### PR DESCRIPTION
Break out encrypt into its own class and Rug function.  Migrate enable
and disable from the old travis-rug-type.

Make repo/repoSlug distinction more clear by using repoSlug more
consistently.

Add content to README and ScalaDoc.  Add change log.

Update project and rug versions.