### PR TITLE
Surface disable-repo, more tests

### DIFF
--- a/src/main/resources/META-INF/services/com.atomist.rug.spi.RugFunction
+++ b/src/main/resources/META-INF/services/com.atomist.rug.spi.RugFunction
@@ -1,4 +1,5 @@
-com.atomist.rug.functions.travis.RestartBuild
-com.atomist.rug.functions.travis.BuildRug
-com.atomist.rug.functions.travis.RepoHook
-com.atomist.rug.functions.travis.Encrypt
+com.atomist.rug.functions.travis.RestartBuildFunction
+com.atomist.rug.functions.travis.BuildRugFunction
+com.atomist.rug.functions.travis.EnableRepoFunction
+com.atomist.rug.functions.travis.DisableRepoFunction
+com.atomist.rug.functions.travis.EncryptFunction

--- a/src/main/scala/com/atomist/rug/functions/travis/BuildRugFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/BuildRugFunction.scala
@@ -1,0 +1,42 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+
+/**
+  * Build any Rug repository from a single builder repository
+  */
+class BuildRugFunction
+  extends AnnotatedRugFunction
+    with TravisFunction {
+
+  /**
+    * Execute travis-build-rug Rug function, which builds an arbitrary Rug archive
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to be built
+    * @param version version of Rug archive to publish
+    * @param teamId Slack team ID connected to the GitHub owner
+    * @param gitRef Git ref to checkout and build
+    * @param travisToken travis-ci.com token with access to atomisthq/rug-build
+    * @param mavenBaseUrl URL of Maven repository without trailing Slack team ID
+    * @param mavenUser user with write access to Maven repository
+    * @param mavenToken API token for Maven user
+    * @param userToken GitHub token with "repo" scope for `owner`/`repo`
+    * @return Rug function reponse indicating success or failure
+    */
+  @RugFunction(name = "travis-build-rug", description = "builds a Rug archive on Travis CI using rug-build",
+    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
+  def build(@Parameter(name = "owner") owner: String,
+            @Parameter(name = "repo") repo: String,
+            @Parameter(name = "version") version: String,
+            @Parameter(name = "teamId") teamId: String,
+            @Parameter(name = "gitRef") gitRef: String,
+            @Secret(name = "travisToken", path = "secret://team?path=travis_token") travisToken: String,
+            @Secret(name = "mavenBaseUrl", path = "secret://team?path=maven_base_url") mavenBaseUrl: String,
+            @Secret(name = "mavenUser", path = "secret://team?path=maven_user") mavenUser: String,
+            @Secret(name = "mavenToken", path = "secret://team?path=maven_token") mavenToken: String,
+            @Secret(name = "userToken", path = "github://user_token?scopes=repo") userToken: String): FunctionResponse =
+    BuildRug(travisEndpoints).build(owner, repo, version, teamId, gitRef, travisToken, mavenBaseUrl,
+      mavenUser, mavenToken, userToken)
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/DisableRepoFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/DisableRepoFunction.scala
@@ -1,0 +1,33 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+import com.typesafe.scalalogging.LazyLogging
+
+/** Disable a GitHub repository in Travis CI */
+class DisableRepoFunction
+  extends AnnotatedRugFunction
+    with TravisFunction
+    with LazyLogging {
+
+  /** Disable Travis CI builds for a GitHub repository
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to disable
+    * @param org Travis CI ".com" or ".org" endpoint
+    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @return Rug Function Response
+    */
+  @RugFunction(name = "travis-disable-repo", description = "Disables Travis CI builds for a GitHub repository",
+    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
+  def disable(
+               @Parameter(name = "owner") owner: String,
+               @Parameter(name = "repo") repo: String,
+               @Parameter(name = "org") org: String,
+               @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
+             ): FunctionResponse = {
+    val disableTravis = false
+    RepoHook(travisEndpoints).tryRepoHook(disableTravis, owner, repo, token, org)
+  }
+
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/EnableRepoFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/EnableRepoFunction.scala
@@ -1,0 +1,35 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+import com.typesafe.scalalogging.LazyLogging
+
+/**
+  *  Enable a GitHub repository in Travis CI
+  */
+class EnableRepoFunction
+  extends AnnotatedRugFunction
+    with TravisFunction
+    with LazyLogging {
+
+  /** Enable Travis CI builds for a GitHub repository
+    *
+    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo name of the repo to enable
+    * @param org Travis CI ".com" or ".org" endpoint
+    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @return Rug FunctionResponse
+    */
+  @RugFunction(name = "travis-enable-repo", description = "Enables Travis CI builds for a GitHub repository",
+    tags = Array(new Tag(name = "travis-ci"), new Tag(name = "ci")))
+  def enable(
+              @Parameter(name = "owner") owner: String,
+              @Parameter(name = "repo") repo: String,
+              @Parameter(name = "org") org: String,
+              @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
+            ): FunctionResponse = {
+    val enableTravis = true
+    RepoHook(travisEndpoints).tryRepoHook(enableTravis, owner, repo, token, org)
+  }
+
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/EncryptFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/EncryptFunction.scala
@@ -1,0 +1,31 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse}
+import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
+
+/**
+  *  Use Travis API to encrypt strings using the repository public key
+  */
+class EncryptFunction
+  extends AnnotatedRugFunction
+    with TravisFunction {
+
+  /** Encrypts a value using Travis CI repo public key
+    *
+    * @param owner   GitHub owner, i.e., user or organization, of the repo to enable
+    * @param repo    name of the repo to enable
+    * @param org     Travis CI ".com" or ".org" endpoint
+    * @param content content to encrypt
+    * @param token   GitHub token with "repo" scope for `owner`/`repo`
+    * @return `content` encrypted using the Travis CI repo public key
+    */
+  @RugFunction(name = "travis-encrypt", description = "Encrypts a value using Travis CI repo public key",
+    tags = Array(new Tag(name = "travis-ci"), new Tag(name = "ci")))
+  def encrypt(@Parameter(name = "owner") owner: String,
+              @Parameter(name = "repo") repo: String,
+              @Parameter(name = "org") org: String,
+              @Parameter(name = "content") content: String,
+              @Secret(name = "user_token", path = "github://user_token?scopes=repo") token: String
+             ): FunctionResponse = Encrypt(travisEndpoints).tryEncrypt(owner, repo, org, content, token)
+
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/RealTravisEndpoints.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RealTravisEndpoints.scala
@@ -1,0 +1,147 @@
+package com.atomist.rug.functions.travis
+
+import java.net.URI
+import java.util
+import java.util.Collections
+
+import scala.collection.JavaConverters._
+
+import org.springframework.http.{HttpHeaders, HttpMethod, HttpStatus, RequestEntity}
+import org.springframework.web.client.{HttpClientErrorException, RestTemplate}
+
+/**
+  *  Implement TravisEndpoints using real Travis CI endpoints
+  */
+class RealTravisEndpoints extends TravisEndpoints {
+
+  private val restTemplate: RestTemplate = new RestTemplate()
+
+  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String = {
+    val request = new RequestEntity[util.Map[String, Object]](
+      headers,
+      HttpMethod.GET,
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug/key")
+    )
+    val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
+    responseEntity.getBody.get("key").asInstanceOf[String]
+  }
+
+  def putHook(endpoint: TravisAPIEndpoint, headers: HttpHeaders, body: util.HashMap[String, Object]): Unit = {
+    val url: String = s"https://api.travis-ci.${endpoint.tld}/hooks"
+    // why are the URL and HTTP action specified twice?
+    val request = new RequestEntity(
+      body,
+      headers,
+      HttpMethod.PUT,
+      URI.create(url)
+    )
+    restTemplate.put(url, request)
+  }
+
+  def postUsersSync(endpoint: TravisAPIEndpoint, headers: HttpHeaders): Unit = {
+    val request = new RequestEntity[util.Map[String, Object]](
+      headers,
+      HttpMethod.POST,
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/users/sync")
+    )
+    try {
+      restTemplate.exchange(request, classOf[util.Map[String, Object]])
+    }
+    catch {
+      case he: HttpClientErrorException if he.getStatusCode == HttpStatus.CONFLICT =>
+    }
+    import scala.util.control.Breaks._
+    breakable {
+      for (i <- 0 to 30) {
+        try {
+          val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
+          if (responseEntity.getStatusCode == HttpStatus.OK) {
+            break
+          }
+        }
+        catch {
+          case he: HttpClientErrorException if he.getStatusCode == HttpStatus.CONFLICT =>
+            print(s"  Waiting for repositories to sync ($i)")
+            Thread.sleep(1000L)
+          case _: Throwable => break
+        }
+      }
+    }
+  }
+
+  def getRepoRetryingWithSync(api: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String ): Int = {
+
+    val id: Int = try {
+      getRepo(api, headers, repoSlug)
+    } catch {
+      case he: HttpClientErrorException if he.getStatusCode == HttpStatus.NOT_FOUND =>
+        postUsersSync(api, headers)
+        getRepo(api, headers, repoSlug)
+    }
+    id
+  }
+
+  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int = {
+    val request = new RequestEntity[util.Map[String, Object]](
+      headers,
+      HttpMethod.GET,
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug")
+    )
+    val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
+    val repoObject: util.Map[String, Object] = responseEntity.getBody.get("repo").asInstanceOf[util.Map[String, Object]]
+    repoObject.get("id").asInstanceOf[Int]
+  }
+
+  // Use evil var to cache token because Travis CI does not want you to
+  // repeatedly get new tokens.
+  private[travis] var travisTokens: util.Map[String, String] = new util.HashMap[String, String]()
+  def postAuthGitHub(endpoint: TravisAPIEndpoint, githubToken: String): String =
+    if (travisTokens.containsKey(githubToken)) {
+      travisTokens.get(githubToken)
+    }
+    else {
+      val request = new RequestEntity(
+        Collections.singletonMap("github_token", githubToken),
+        TravisEndpoints.headers,
+        HttpMethod.POST,
+        URI.create(s"https://api.travis-ci.${endpoint.tld}/auth/github")
+      )
+      val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, String]])
+      val travisToken = responseEntity.getBody.get("access_token")
+      travisTokens.put(githubToken, travisToken)
+      travisToken
+    }
+
+  def postRestartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, number: Int): Unit = {
+    val request = new RequestEntity[util.Map[String, Object]](
+      headers,
+      HttpMethod.POST,
+      URI.create(s"https://api.travis-ci.${endpoint.tld}/builds/$number/restart")
+    )
+    restTemplate.exchange(request, classOf[util.Map[String, Object]])
+  }
+
+  def postStartBuild(
+                      endpoint: TravisAPIEndpoint,
+                      headers: HttpHeaders,
+                      repoSlug: String,
+                      message: String,
+                      envVars: Seq[String]): Unit = {
+    val body = Collections.singletonMap[String, Object]("request", Collections.unmodifiableMap[String, Object](Map(
+      "message" -> s"API initiated Travis CI build: $message",
+      "branch" -> "master",
+      "config" -> Collections.singletonMap[String, Object](
+        "env", Collections.singletonMap[String, Object]("global", Collections.unmodifiableList[String](envVars.asJava)))
+    ).asJava))
+    val escapedRepoSlug = repoSlug.replace("/", "%2F")
+    val urlString = s"https://api.travis-ci.${endpoint.tld}/repo/$escapedRepoSlug/requests"
+    headers.add("Travis-API-Version", "3")
+    val request = new RequestEntity(
+      body,
+      headers,
+      HttpMethod.POST,
+      URI.create(urlString)
+    )
+    restTemplate.exchange(request, classOf[util.Map[String, Object]])
+  }
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
@@ -2,69 +2,20 @@ package com.atomist.rug.functions.travis
 
 import java.util
 
-import com.atomist.rug.runtime.Rug
 import com.atomist.rug.spi.Handlers.Status
-import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse, StringBodyOption}
-import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
-import com.typesafe.scalalogging.LazyLogging
+import com.atomist.rug.spi.{FunctionResponse, StringBodyOption}
 import org.springframework.http.HttpHeaders
 
 /**
-  * Enable and disable repos in Travis CI.
+  * Enable and disable repositories in Travis CI
   */
-class RepoHook extends AnnotatedRugFunction
-  with Rug
-  with LazyLogging {
+case class RepoHook(travisEndpoints: TravisEndpoints) {
 
-  private val travisEndpoints = new RealTravisEndpoints
-
-  /**
-    * Enable Travis CI builds for a GitHub repository.
-    *
-    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
-    * @param repo name of the repo to enable
-    * @param org Travis CI ".com" or ".org" endpoint
-    * @param token GitHub token with "repo" scope for `owner`/`repo`
-    * @return
-    */
-  @RugFunction(name = "travis-enable-repo", description = "Enables Travis CI builds for a GitHub repository",
-    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
-  def enable(
-              @Parameter(name = "owner") owner: String,
-              @Parameter(name = "repo") repo: String,
-              @Parameter(name = "org") org: String,
-              @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
-            ): FunctionResponse = {
-    val enableTravis = true
-    tryRepoEnabler(enableTravis, owner, repo, token, org)
-  }
-
-  /**
-    * Disable Travis CI builds for a GitHub repository.
-    *
-    * @param owner GitHub owner, i.e., user or organization, of the repo to enable
-    * @param repo name of the repo to disable
-    * @param org Travis CI ".com" or ".org" endpoint
-    * @param token GitHub token with "repo" scope for `owner`/`repo`
-    * @return
-    */
-  @RugFunction(name = "travis-disable-repo", description = "Disables Travis CI builds for a GitHub repository",
-    tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
-  def disable(
-               @Parameter(name = "owner") owner: String,
-               @Parameter(name = "repo") repo: String,
-               @Parameter(name = "org") org: String,
-               @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
-             ): FunctionResponse = {
-    val disableTravis = false
-    tryRepoEnabler(disableTravis, owner, repo, token, org)
-  }
-
-  private def tryRepoEnabler(active: Boolean, owner: String, repo: String, githubToken: String, org: String): FunctionResponse = {
+  def tryRepoHook(active: Boolean, owner: String, repo: String, githubToken: String, org: String): FunctionResponse = {
     val repoSlug = s"$owner/$repo"
     val activeString = if (active) "enable" else "disable"
     try {
-      repoEnabler(active, repoSlug, githubToken, org)
+      authPutHook(active, repoSlug, githubToken, org)
       FunctionResponse(Status.Success, Option(s"Successfully ${activeString}d Travis CI for $repoSlug"), None, None)
     } catch {
       case e: Exception =>
@@ -77,10 +28,10 @@ class RepoHook extends AnnotatedRugFunction
     }
   }
 
-  private[travis] def repoEnabler(active: Boolean, repoSlug: String, githubToken: String, org: String): Unit = {
+  private def authPutHook(active: Boolean, repoSlug: String, githubToken: String, org: String): Unit = {
     val api: TravisAPIEndpoint = TravisAPIEndpoint.stringToTravisEndpoint(org)
     val token: String = travisEndpoints.postAuthGitHub(api, githubToken)
-    val headers: HttpHeaders = TravisEndpoints.authHeaders(api, token)
+    val headers: HttpHeaders = TravisEndpoints.authHeaders(token)
 
     val id: Int = travisEndpoints.getRepoRetryingWithSync(api, headers, repoSlug)
 
@@ -92,6 +43,5 @@ class RepoHook extends AnnotatedRugFunction
 
     travisEndpoints.putHook(api, headers, body)
   }
-
 
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/RestartBuildFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RestartBuildFunction.scala
@@ -1,6 +1,5 @@
 package com.atomist.rug.functions.travis
 
-import com.atomist.rug.runtime.Rug
 import com.atomist.rug.spi.Handlers.Status
 import com.atomist.rug.spi.annotation.{Parameter, RugFunction, Secret, Tag}
 import com.atomist.rug.spi.{AnnotatedRugFunction, FunctionResponse, StringBodyOption}
@@ -10,12 +9,10 @@ import org.springframework.http.HttpHeaders
 /**
   * Restart a travis-ci build
   */
-class RestartBuild
+class RestartBuildFunction
   extends AnnotatedRugFunction
-    with Rug
-    with LazyLogging{
-
-  private val travisEndpoints = new RealTravisEndpoints
+    with TravisFunction
+    with LazyLogging {
 
   @RugFunction(name = "restart-travis-build", description = "Restarts a travis build",
     tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
@@ -25,7 +22,7 @@ class RestartBuild
 
       val api: TravisAPIEndpoint = TravisAPIEndpoint.stringToTravisEndpoint(org)
       val travisToken: String = travisEndpoints.postAuthGitHub(api, token)
-      val headers: HttpHeaders = TravisEndpoints.authHeaders(api, travisToken)
+      val headers: HttpHeaders = TravisEndpoints.authHeaders(travisToken)
       try {
         travisEndpoints.postRestartBuild(api, headers, buildId)
         FunctionResponse(Status.Success, Option(s"Successfully restarted build `$buildId` on Travis CI"), None, None)

--- a/src/main/scala/com/atomist/rug/functions/travis/TravisAPIEndpoint.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/TravisAPIEndpoint.scala
@@ -1,0 +1,33 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.InvalidRugParameterPatternException
+
+trait TravisAPIEndpoint {
+
+  def tld: String
+
+}
+
+object TravisAPIEndpoint {
+
+  def stringToTravisEndpoint(ep: String): TravisAPIEndpoint = ep match {
+    case ".org" | "org" => TravisOrgEndpoint
+    case ".com" | "com" => TravisComEndpoint
+    case _ => throw new InvalidRugParameterPatternException("Travis CI endpoint must be 'org' or 'com'")
+  }
+
+  def isPublic(ep: String): Boolean = ep match {
+    case ".org" | "org" => true
+    case ".com" | "com" => false
+    case _ => throw new InvalidRugParameterPatternException("Travis CI endpoint must be 'org' or 'com'")
+  }
+
+}
+
+object TravisOrgEndpoint extends TravisAPIEndpoint {
+  val tld: String = "org"
+}
+
+object TravisComEndpoint extends TravisAPIEndpoint {
+  val tld: String = "com"
+}

--- a/src/main/scala/com/atomist/rug/functions/travis/TravisEndpoints.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/TravisEndpoints.scala
@@ -1,45 +1,11 @@
 package com.atomist.rug.functions.travis
 
-import java.net.URI
 import java.util
-import java.util.Collections
-import scala.collection.JavaConverters._
 
-import com.atomist.rug.InvalidRugParameterPatternException
-import org.springframework.http.{HttpHeaders, HttpMethod, HttpStatus, RequestEntity}
-import org.springframework.web.client.{HttpClientErrorException, RestTemplate}
-
-trait TravisAPIEndpoint {
-
-  def tld: String
-
-}
-
-object TravisAPIEndpoint {
-
-  def stringToTravisEndpoint(ep: String): TravisAPIEndpoint = ep match {
-    case ".org" | "org" => TravisOrgEndpoint
-    case ".com" | "com" => TravisComEndpoint
-    case _ => throw new InvalidRugParameterPatternException("Travis CI endpoint must be 'org' or 'com'")
-  }
-
-  def isPublic(ep: String): Boolean = ep match {
-    case ".org" | "org" => true
-    case ".com" | "com" => false
-    case _ => throw new InvalidRugParameterPatternException("Travis CI endpoint must be 'org' or 'com'")
-  }
-
-}
-
-object TravisOrgEndpoint extends TravisAPIEndpoint {
-  val tld: String = "org"
-}
-
-object TravisComEndpoint extends TravisAPIEndpoint {
-  val tld: String = "com"
-}
+import org.springframework.http.HttpHeaders
 
 trait TravisEndpoints {
+
   /** Return the key of the repo.
     *
     * @param endpoint org|com
@@ -96,18 +62,37 @@ trait TravisEndpoints {
     * @param endpoint org|com
     * @param headers standard Travis API headers
     * @param repoSlug repo slug, e.g., "atomist-rugs/rug-editors"
+    * @param message build message, i.e., message displayed at the top of the
+    *                build page on Travis CI
+    * @param envVars global environment variables to supply to build that will override
+    *                any global environment variables in the build's .travis.yml
     */
-  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String, message: String, envVars: Seq[String]): Unit
+  def postStartBuild(
+                      endpoint: TravisAPIEndpoint,
+                      headers: HttpHeaders,
+                      repoSlug: String,
+                      message: String,
+                      envVars: Seq[String]): Unit
+
+  /** Get the repository identifier from Travis CI.  If the initial attempt
+    * fails, sync repositories and try again.
+    *
+    * @param api org|com
+    * @param headers standard Travis API headers
+    * @param repoSlug repo slug, e.g., "atomist-rugs/rug-editors"
+    * @return Travis CI repository identifier
+    */
+  def getRepoRetryingWithSync(api: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String ): Int
+
 }
 
 object TravisEndpoints {
 
   /** Construct standard Travis API headers.
     *
-    * @param endpoint org|com
     * @return Travis API headers
     */
-  def headers(endpoint: TravisAPIEndpoint): HttpHeaders = {
+  def headers: HttpHeaders = {
     val noAuthHeaders = new HttpHeaders()
     noAuthHeaders.add("Content-Type", "application/json")
     noAuthHeaders.add("Accept", "application/vnd.travis-ci.2+json")
@@ -117,143 +102,13 @@ object TravisEndpoints {
 
   /** Construct standard Travis API headers with Authorization token.
     *
-    * @param endpoint org|com
     * @param token Travis API token returned from TravisEndpoints.postAuthGitHub
     * @return Travis API headers
     */
-  def authHeaders(endpoint: TravisAPIEndpoint, token: String): HttpHeaders = {
-    val hdrs = headers(endpoint)
+  def authHeaders(token: String): HttpHeaders = {
+    val hdrs = headers
     hdrs.add("Authorization", s"""token "$token"""")
     hdrs
   }
-}
 
-class RealTravisEndpoints extends TravisEndpoints {
-
-  private val restTemplate: RestTemplate = new RestTemplate()
-
-  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String = {
-    val request = new RequestEntity[util.Map[String, Object]](
-      headers,
-      HttpMethod.GET,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug/key")
-    )
-    val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
-    responseEntity.getBody.get("key").asInstanceOf[String]
-  }
-
-  def putHook(endpoint: TravisAPIEndpoint, headers: HttpHeaders, body: util.HashMap[String, Object]): Unit = {
-    val url: String = s"https://api.travis-ci.${endpoint.tld}/hooks"
-    // why are the URL and HTTP action specified twice?
-    val request = new RequestEntity(
-      body,
-      headers,
-      HttpMethod.PUT,
-      URI.create(url)
-    )
-    restTemplate.put(url, request)
-  }
-
-  def postUsersSync(endpoint: TravisAPIEndpoint, headers: HttpHeaders): Unit = {
-    val request = new RequestEntity[util.Map[String, Object]](
-      headers,
-      HttpMethod.POST,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/users/sync")
-    )
-    try {
-      restTemplate.exchange(request, classOf[util.Map[String, Object]])
-    }
-    catch {
-      case he: HttpClientErrorException if he.getStatusCode == HttpStatus.CONFLICT =>
-    }
-    import scala.util.control.Breaks._
-    breakable {
-      for (i <- 0 to 30) {
-        try {
-          val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
-          if (responseEntity.getStatusCode == HttpStatus.OK) {
-            break
-          }
-        }
-        catch {
-          case he: HttpClientErrorException if he.getStatusCode == HttpStatus.CONFLICT =>
-            print(s"  Waiting for repositories to sync ($i)")
-            Thread.sleep(1000L)
-          case _: Throwable => break
-        }
-      }
-    }
-  }
-
-
-  def getRepoRetryingWithSync(api: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String ): Int = {
-
-    val id: Int = try {
-      getRepo(api, headers, repoSlug)
-    } catch {
-      case he: HttpClientErrorException if he.getStatusCode == HttpStatus.NOT_FOUND =>
-        postUsersSync(api, headers)
-        getRepo(api, headers, repoSlug)
-    }
-    id
-  }
-
-  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int = {
-    val request = new RequestEntity[util.Map[String, Object]](
-      headers,
-      HttpMethod.GET,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/repos/$repoSlug")
-    )
-    val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, Object]])
-    val repoObject: util.Map[String, Object] = responseEntity.getBody.get("repo").asInstanceOf[util.Map[String, Object]]
-    repoObject.get("id").asInstanceOf[Int]
-  }
-
-  // Use evil var to cache token because Travis CI does not want you to
-  // repeatedly get new tokens.
-  private[travis] var travisTokens: util.Map[String, String] = new util.HashMap[String, String]()
-  def postAuthGitHub(endpoint: TravisAPIEndpoint, githubToken: String): String =
-    if (travisTokens.containsKey(githubToken)) {
-      travisTokens.get(githubToken)
-    }
-    else {
-      val request = new RequestEntity(
-        Collections.singletonMap("github_token", githubToken),
-        TravisEndpoints.headers(endpoint),
-        HttpMethod.POST,
-        URI.create(s"https://api.travis-ci.${endpoint.tld}/auth/github")
-      )
-      val responseEntity = restTemplate.exchange(request, classOf[util.Map[String, String]])
-      val travisToken = responseEntity.getBody.get("access_token")
-      travisTokens.put(githubToken, travisToken)
-      travisToken
-    }
-
-  def postRestartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, number: Int): Unit = {
-    val request = new RequestEntity[util.Map[String, Object]](
-      headers,
-      HttpMethod.POST,
-      URI.create(s"https://api.travis-ci.${endpoint.tld}/builds/$number/restart")
-    )
-    restTemplate.exchange(request, classOf[util.Map[String, Object]])
-  }
-
-  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String, message: String, envVars: Seq[String]): Unit = {
-    val body = Collections.singletonMap[String, Object]("request", Collections.unmodifiableMap[String, Object](Map(
-      "message" -> s"API initiated Travis CI build: $message",
-      "branch" -> "master",
-      "config" -> Collections.singletonMap[String, Object](
-        "env", Collections.singletonMap[String, Object]("global", Collections.unmodifiableList[String](envVars.asJava)))
-    ).asJava))
-    val escapedRepoSlug = repoSlug.replace("/", "%2F")
-    val urlString = s"https://api.travis-ci.${endpoint.tld}/repo/$escapedRepoSlug/requests"
-    headers.add("Travis-API-Version", "3")
-    val request = new RequestEntity(
-      body,
-      headers,
-      HttpMethod.POST,
-      URI.create(urlString)
-    )
-    restTemplate.exchange(request, classOf[util.Map[String, Object]])
-  }
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/TravisFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/TravisFunction.scala
@@ -1,0 +1,13 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.runtime.Rug
+
+/**
+  * Base trait for all Travis Rug functions providing an implementation
+  * of TravisEndpoints
+  */
+trait TravisFunction extends Rug {
+
+  lazy val travisEndpoints: TravisEndpoints = new RealTravisEndpoints
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/BuildRugTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/BuildRugTest.scala
@@ -1,0 +1,19 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.Handlers.Status
+import org.scalatest.{FlatSpec, Matchers}
+
+class BuildRugTest extends FlatSpec with Matchers {
+
+  import FunctionResponseHelpers._
+
+  it should "return failure when starting a build fails" in {
+    val failBuild = new BuildRug(new FailTravisEndpoints)
+    val fr = failBuild.build("noone", "nothing", "2.7.1828", "TK421", "master", "nottravistoken",
+      "https://company.jfrog.io/company", "124kt", "nomaventoken", "notusertoken")
+    assert(fr.status === Status.Failure)
+    val expected = "Failed to start build for noone/nothing on Travis CI"
+    checkResponseMessage(fr.msg, expected)
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/EncryptTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/EncryptTest.scala
@@ -1,0 +1,67 @@
+package com.atomist.rug.functions.travis
+
+import java.io.StringReader
+import java.security.{KeyFactory, Security}
+import java.security.spec.{PKCS8EncodedKeySpec, X509EncodedKeySpec}
+import java.util.Base64
+import javax.crypto.Cipher
+
+import com.atomist.rug.spi.Handlers.Status
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.bouncycastle.openssl.{PEMKeyPair, PEMParser}
+import org.scalatest.{FlatSpec, Matchers}
+
+class EncryptTest extends FlatSpec with Matchers {
+
+  val msg = "Bottle Up and Explode!"
+
+  private def decryptString(encryptedString: String): String = {
+    val parser = new PEMParser(new StringReader(MockTravisEndpoints.mockPrivateKey))
+    val ob = parser.readObject().asInstanceOf[PEMKeyPair]
+
+    val privateKeySpec = new PKCS8EncodedKeySpec(ob.getPrivateKeyInfo().getEncoded())
+    val keyFactory = KeyFactory.getInstance("RSA")
+    val privateKey = keyFactory.generatePrivate(privateKeySpec)
+
+    val rsaCipher = Cipher.getInstance("RSA/ECB/PKCS1Padding")
+    rsaCipher.init(Cipher.DECRYPT_MODE, privateKey)
+
+    val decoded = Base64.getDecoder.decode(encryptedString)
+    val decrypted = rsaCipher.doFinal(decoded)
+    new String(decrypted, "UTF-8")
+  }
+
+  it should "encrypt a simple message" in {
+    val encrypt = new Encrypt(new MockTravisEndpoints)
+    val headers = TravisEndpoints.authHeaders("notaghtoken")
+    val result = encrypt.encryptString("noone/nothing", TravisOrgEndpoint, headers, msg)
+    assert(decryptString(result) === msg)
+  }
+
+  it should "respond with encrypted message in response body" in {
+    val encrypt = new Encrypt(new MockTravisEndpoints)
+    val resp = encrypt.tryEncrypt("noone", "nothing", ".org", msg, "bunktoken")
+    assert(resp.status === Status.Success)
+    resp.body match {
+      case Some(b) => b.str match {
+        case Some(s) if decryptString(s) === msg =>
+        case Some(x) => fail(s"encrypted message did not match expected: $x")
+        case None => fail(s"response body did not contain encrypted message")
+      }
+      case None => fail(s"response did not have a body")
+    }
+  }
+
+  it should "properly fail if travis api fails" in {
+    val encrypt = new Encrypt(new FailTravisEndpoints)
+    val resp = encrypt.tryEncrypt("noone", "nothing", ".org", msg, "invalidtoken")
+    assert(resp.status === Status.Failure)
+  }
+
+}
+
+object EncryptTest {
+
+  Security.addProvider(new BouncyCastleProvider());
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/FailTravisEndpoints.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/FailTravisEndpoints.scala
@@ -1,0 +1,28 @@
+package com.atomist.rug.functions.travis
+
+import java.util
+
+import org.springframework.http.HttpHeaders
+
+class FailTravisEndpoints extends TravisEndpoints {
+
+  val e = new Exception("fail travis endpoint, fail")
+
+  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String = throw e
+
+  def putHook(endpoint: TravisAPIEndpoint, headers: HttpHeaders, body: util.HashMap[String, Object]): Unit = throw e
+
+  def postUsersSync(endpoint: TravisAPIEndpoint, headers: HttpHeaders): Unit = throw e
+
+  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int = throw e
+
+  def postAuthGitHub(endpoint: TravisAPIEndpoint, githubToken: String): String = throw e
+
+  def postRestartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, number: Int): Unit = throw e
+
+  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String,
+                     message: String, envVars: Seq[String]): Unit = throw e
+
+  def getRepoRetryingWithSync(api: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String ): Int = throw e
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/FunctionResponseHelpers.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/FunctionResponseHelpers.scala
@@ -1,0 +1,13 @@
+package com.atomist.rug.functions.travis
+
+import org.scalatest.FlatSpec
+
+object FunctionResponseHelpers extends FlatSpec {
+
+  def checkResponseMessage(msgOption: Option[String], expected: String): Unit = msgOption match {
+    case Some(m) if m === expected =>
+    case Some(x) => fail(s"response message ($x) did not match expected ($expected)")
+    case None => fail(s"response did not contain a message")
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/MockTravisEndpoints.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/MockTravisEndpoints.scala
@@ -1,0 +1,76 @@
+package com.atomist.rug.functions.travis
+
+import java.util
+
+import org.springframework.http.HttpHeaders
+
+object MockTravisEndpoints {
+  // we cannot use a static value for the encrypted message
+  // because https://en.wikipedia.org/wiki/RSA_(cryptosystem)#Padding_schemes
+  // do not use this private key for anything real
+  val mockPrivateKey = """-----BEGIN RSA PRIVATE KEY-----
+                         |MIIEowIBAAKCAQEAtp/Bix4/Px0skmWkaCLSYhwzuw4yrOCVdZf2dYC7k0CR2FnQ
+                         |UpRCGsfo1JAX2eo+V/WXqXkbrJpesh+1MqxsLCKqngMmciR6zx/gybQXSfaq3HgC
+                         |yrLDcY9nQqICsHnnKW7FVaL7riCb2cyA52ebu1tyBpSEiXx8EFF65zY7Z+q1jcfO
+                         |D0k7a0EpnlS+EJHYpsE8L83XFNq8vXzTAHkjvQhaze5jk42r7nVxfc3GIBvq0Jnh
+                         |eNw9dTAmNBfgBVKBSNaPvo3NymsK86MrVkyWcf4YbO6qe6/Yb7z2VJYFzgUGypri
+                         |OmgNJsmPz/P/+D0fyAZJGbI9mf9CwwCdUce3/QIDAQABAoIBAGb98cjjZgfSDDED
+                         |4ZRZDw0FmqcDetDEV4XaDcR2tVJ2N8or3LC1rBIua8B1Av6CfGZeuwl4o4LUDFOo
+                         |Tigl1VuOsWornKMCr7/f2oXmarvrwLBVfj2SU2bX2QRbGeks1pEnR2LkZ8vr1/kc
+                         |vBXE+K7RA51yZMykx9LsIMQEcbxITMoUAHOV3U6hGzfdNaJonql4tbq8zVaZyTY0
+                         |xH3mRkdGUXusbihr6OonVq+twB+GJ5knJ2+aNoBAJ08C0djui4v1dNXf6hPOtP48
+                         |WhP1mSu04nnrmiySQWJNyAmL+JUVBlzUB0TsDTsshTfQtUpxZguOZoJ/ziIGUAg8
+                         |MGbCGoECgYEA7p4kDMH/B2dnsvhDq/FuW6hxunRuqTrSje1tdICtfHMG9ejiTKiI
+                         |eoHliYvOZZFStaXQAcoKNaXnLTleYlagHpaphAyvif610sf9bGrQ+pQH9s393d67
+                         |ta3GoUJkMNoZcvDdVt8bPq6I30z4Hvh76deiRMF3oS8YFKux4sDh8ecCgYEAw+1q
+                         |8OcttzKgp3WUMO7VBLyKsQd9RFM48jFgTmlVtZonWHgDJ9cdArnNvTrjVyge71qP
+                         |zHa7miI+uXvfm6JIL8F2Z5lX8sI6JT2zwz1iB1sX8d1Y1U+8Lz/AZqQewXDVcdCx
+                         |GpaRK0n437En5T5vFnyM5Ws/Jn1hLm7+i1XP0nsCgYARv+u4kzmwSE3bb0JBaQ0n
+                         |fkkvcHfG2NxOuGma7/N3vWq4IiGrSCIW0tDLQX4R6hR39KSbbXcC9JtUrt7Je94f
+                         |SF/Ftdfc8Ph/fGbqiKuQ6DALeNk4htf5tLqAxlqDk8Wu2iHs013IdN0zlxsh2qQF
+                         |CghFCwsmD0XAS+FIl8Z24wKBgEmGhUVWXA+NzkBJnY0nc4VNg/afSuEjIhGxeeSz
+                         |HtkBupY2o2iGD3sAYzcKLFp+0e0c3S3ruMdE5qkQ1X9ATTqurVJ/d0PAo7VqDFXO
+                         |aUU9aCT53eZe/83zbK6YFHqfb1pA6NWDf4LxRZYck04yOdoEb5OAxbgaASg9uwRq
+                         |9YyVAoGBAICFOPYVh2ZeXd79xsH7GCwFkVxmk6Y4U5taBZqBaZ3P90nG9OMLbDL0
+                         |6AGynrzGjwpRMN1Ez8CL8froJtv0ydX6lbuRTDau79iaF7FZmSNQtwhJcul3v/h7
+                         |IPrAO+i7WyqB5L4j2hEJ3qkIhtRmVgF8iCxxhLHcJXmRrqwvQnN/
+                         |-----END RSA PRIVATE KEY-----
+                         |""".stripMargin
+  val mockRepoKey = """-----BEGIN PUBLIC KEY-----
+                      |MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtp/Bix4/Px0skmWkaCLS
+                      |Yhwzuw4yrOCVdZf2dYC7k0CR2FnQUpRCGsfo1JAX2eo+V/WXqXkbrJpesh+1Mqxs
+                      |LCKqngMmciR6zx/gybQXSfaq3HgCyrLDcY9nQqICsHnnKW7FVaL7riCb2cyA52eb
+                      |u1tyBpSEiXx8EFF65zY7Z+q1jcfOD0k7a0EpnlS+EJHYpsE8L83XFNq8vXzTAHkj
+                      |vQhaze5jk42r7nVxfc3GIBvq0JnheNw9dTAmNBfgBVKBSNaPvo3NymsK86MrVkyW
+                      |cf4YbO6qe6/Yb7z2VJYFzgUGypriOmgNJsmPz/P/+D0fyAZJGbI9mf9CwwCdUce3
+                      |/QIDAQAB
+                      |-----END PUBLIC KEY-----
+                      |""".stripMargin
+  val mockRepoId = 8675309
+  val mockTravisToken = "xZ-dkkuUBH7823CMfm3WeR"
+}
+
+class MockTravisEndpoints extends TravisEndpoints {
+
+  import MockTravisEndpoints._
+
+  def getRepoKey(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): String = mockRepoKey
+
+  def putHook(endpoint: TravisAPIEndpoint, headers: HttpHeaders, body: util.HashMap[String, Object]): Unit = Unit
+
+  def postUsersSync(endpoint: TravisAPIEndpoint, headers: HttpHeaders): Unit = Unit
+
+  def getRepo(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String): Int = mockRepoId
+
+  def postAuthGitHub(endpoint: TravisAPIEndpoint, githubToken: String): String = mockTravisToken
+
+  def postRestartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, number: Int): Unit = Unit
+
+  def postStartBuild(endpoint: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String,
+                     message: String, envVars: Seq[String]): Unit = Unit
+
+  def getRepoRetryingWithSync(api: TravisAPIEndpoint, headers: HttpHeaders, repoSlug: String ): Int =
+    getRepo(api, headers, repoSlug)
+
+}
+

--- a/src/test/scala/com/atomist/rug/functions/travis/RealTravisEndpointsTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/RealTravisEndpointsTest.scala
@@ -1,0 +1,17 @@
+package com.atomist.rug.functions.travis
+
+import java.util.Collections
+
+import com.atomist.rug.InvalidRugParameterPatternException
+import org.scalatest.{FlatSpec, Matchers}
+
+class RealTravisEndpointsTest extends FlatSpec with Matchers {
+
+  it should "return cached token" in {
+    val t: String = "notarealtravistoken"
+    val rte: RealTravisEndpoints = new RealTravisEndpoints
+    rte.travisTokens = Collections.singletonMap("doesnotmatter", "notarealtravistoken")
+    val api: TravisAPIEndpoint = TravisOrgEndpoint
+    assert(rte.postAuthGitHub(api, "doesnotmatter") === t)
+  }
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/RepoHookTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/RepoHookTest.scala
@@ -1,0 +1,44 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.spi.Handlers.Status
+import org.scalatest.{FlatSpec, Matchers}
+
+class RepoHookTest extends FlatSpec with Matchers {
+
+  import FunctionResponseHelpers._
+
+  val mockTravisEndpoints: TravisEndpoints = new MockTravisEndpoints
+  val repoHook = new RepoHook(mockTravisEndpoints)
+
+  it should "enable a repo" in {
+    val fr = repoHook.tryRepoHook(true, "noone", "nothing", "notoken", ".org")
+    assert(fr.status === Status.Success)
+    val expected = "Successfully enabled Travis CI for noone/nothing"
+    checkResponseMessage(fr.msg, expected)
+  }
+
+  it should "disable a repo" in {
+    val fr = repoHook.tryRepoHook(false, "noone", "nothing", "notoken", ".org")
+    assert(fr.status === Status.Success)
+    val expected = "Successfully disabled Travis CI for noone/nothing"
+    checkResponseMessage(fr.msg, expected)
+  }
+
+  val failTravisEndpoints: TravisEndpoints = new FailTravisEndpoints
+  val failHook = new RepoHook(failTravisEndpoints)
+
+  it should "return failure when enabling a repo fails" in {
+    val fr = failHook.tryRepoHook(true, "noone", "nothing", "notoken", ".org")
+    assert(fr.status === Status.Failure)
+    val expected = "Failed to enable Travis CI for noone/nothing"
+    checkResponseMessage(fr.msg, expected)
+  }
+
+  it should "return failure when disabling a repo fails" in {
+    val fr = failHook.tryRepoHook(false, "noone", "nothing", "notoken", ".org")
+    assert(fr.status === Status.Failure)
+    val expected = "Failed to disable Travis CI for noone/nothing"
+    checkResponseMessage(fr.msg, expected)
+  }
+
+}

--- a/src/test/scala/com/atomist/rug/functions/travis/TravisAPIEndpointTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/TravisAPIEndpointTest.scala
@@ -1,0 +1,30 @@
+package com.atomist.rug.functions.travis
+
+import com.atomist.rug.InvalidRugParameterPatternException
+import org.scalatest.{FlatSpec, Matchers}
+
+class TravisAPIEndpointTest extends FlatSpec with Matchers {
+
+  import TravisAPIEndpoint._
+
+  "stringToTravisEndpoint" should "accept org" in {
+    assert(stringToTravisEndpoint("org") === TravisOrgEndpoint)
+  }
+
+  it should "accept .org" in {
+    assert(stringToTravisEndpoint(".org") === TravisOrgEndpoint)
+  }
+
+  it should "accept com" in {
+    assert(stringToTravisEndpoint("com") === TravisComEndpoint)
+  }
+
+  it should "accept .com" in {
+    assert(stringToTravisEndpoint(".com") === TravisComEndpoint)
+  }
+
+  it should "throw an exception if not given a valid API type" in {
+    an[InvalidRugParameterPatternException] should be thrownBy stringToTravisEndpoint(".blah")
+  }
+
+}


### PR DESCRIPTION
Move the enabling and disabling repository Rug functions into their
own classes so one of them is no longer hidden and add tests.
Refactor the build Rug and encrypt functions to be more testable, add
tests.  Move classes out into their own files.

Fixes #4
Closes #5