### PR TITLE
Retry all Travis API calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,33 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/atomist/rug-functions-travis/compare/0.14.0...HEAD
+[Unreleased]: https://github.com/atomist/rug-functions-travis/compare/0.14.1...HEAD
+
+### Changed
+
+-   Updated rug dependency to 1.0.0-m.2
+-   Silence logging in tests
+
+### Added
+
+-   Retry to all Travis API calls
+-   More exception logging
+
+## [0.14.1] - 2017-05-02
+
+[0.14.1]: https://github.com/atomist/rug-functions-travis/compare/0.14.0...0.14.1
+
+### Changed
+
+-   Retry of repo get in `getRepoRetryingWithSync`
 
 ## [0.14.0] - 2017-05-01
 
 [0.14.0]: https://github.com/atomist/rug-functions-travis/compare/0.13.0...0.14.0
 
-### Changed
+### Added
 
--   Add some exception logging to figure out why enable-repo tends to fail
+-   Exception logging to figure out why enable-repo tends to fail
 
 ## [0.13.0] - 2017-04-20
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.atomist.rug</groupId>
     <artifactId>rug-functions-travis</artifactId>
-    <version>0.14.1-SNAPSHOT</version>
+    <version>0.15.0-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>rug-functions-travis</name>
     <description>rug-functions-travis</description>
@@ -14,7 +14,7 @@
         <java.version>1.8</java.version>
         <scala.version>2.11.8</scala.version>
         <scala.binary.version>2.11</scala.binary.version>
-        <rug.version>[0.25.1,0.26.0)</rug.version>
+        <rug.version>[1.0.0-m.2,2.0.0)</rug.version>
     </properties>
     <dependencies>
         <dependency>

--- a/src/main/scala/com/atomist/rug/functions/travis/BuildRug.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/BuildRug.scala
@@ -2,12 +2,13 @@ package com.atomist.rug.functions.travis
 
 import com.atomist.rug.spi.Handlers.Status
 import com.atomist.rug.spi.{FunctionResponse, StringBodyOption}
+import com.typesafe.scalalogging.LazyLogging
 import org.springframework.http.HttpHeaders
 
 /**
   * Build any Rug project on Travis CI using a single repo
   */
-case class BuildRug(travisEndpoints: TravisEndpoints) {
+case class BuildRug(travisEndpoints: TravisEndpoints) extends LazyLogging {
 
   /** Build any Rug project using a single GitHub repo's Travis CI build
     *
@@ -61,8 +62,9 @@ case class BuildRug(travisEndpoints: TravisEndpoints) {
       FunctionResponse(Status.Success, Option(s"Successfully started build for $owner/$repo on Travis CI"), None, None)
     } catch {
       case e: Exception =>
+        logger.error(s"starting build for $owner/$repo failed: ${e.getMessage}", e)
         FunctionResponse(Status.Failure, Some(s"Failed to start build for $owner/$repo on Travis CI"),
-          None, StringBodyOption(e.getMessage))
+          None, StringBodyOption(s"${e.getMessage}\n$e"))
     }
   }
 

--- a/src/main/scala/com/atomist/rug/functions/travis/Encrypt.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/Encrypt.scala
@@ -8,6 +8,7 @@ import javax.crypto.Cipher
 
 import com.atomist.rug.spi.{FunctionResponse, StringBodyOption}
 import com.atomist.rug.spi.Handlers.Status
+import com.typesafe.scalalogging.LazyLogging
 import org.bouncycastle.asn1.x509.SubjectPublicKeyInfo
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.openssl.PEMParser
@@ -16,7 +17,7 @@ import org.springframework.http.HttpHeaders
 /**
   * Encrypt values for Travis CI
   */
-case class Encrypt(travisEndpoints: TravisEndpoints) {
+case class Encrypt(travisEndpoints: TravisEndpoints) extends LazyLogging {
 
   /** Fetch Travis public key for repo and encrypt content
     *
@@ -50,11 +51,12 @@ case class Encrypt(travisEndpoints: TravisEndpoints) {
       )
     } catch {
       case e: Exception =>
+        logger.error(s"failed to encrypt content for $repoSlug: ${e.getMessage}", e)
         FunctionResponse(
           Status.Failure,
           Some(s"Failed to encrypt content for $repoSlug"),
           None,
-          StringBodyOption(e.getMessage)
+          StringBodyOption(s"${e.getMessage}\n$e")
         )
     }
   }

--- a/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RepoHook.scala
@@ -21,7 +21,7 @@ case class RepoHook(travisEndpoints: TravisEndpoints)
       FunctionResponse(Status.Success, Option(s"Successfully ${activeString}d Travis CI for $repoSlug"), None, None)
     } catch {
       case e: Exception =>
-        logger.error(e.getMessage, e)
+        logger.error(s"$activeString for $owner/$repo failed: ${e.getMessage}", e)
         FunctionResponse(
           Status.Failure,
           Some(s"Failed to $activeString Travis CI for $repoSlug"),

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,10 @@
+<configuration>
+	<appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+		<encoder class="ch.qos.logback.classic.encoder.PatternLayoutEncoder">
+			<pattern>%msg%n</pattern>
+		</encoder>
+	</appender>
+	<root level="OFF">
+		<appender-ref ref="CONSOLE"/>
+	</root>
+</configuration>

--- a/src/test/scala/com/atomist/rug/functions/travis/RealTravisEndpointsTest.scala
+++ b/src/test/scala/com/atomist/rug/functions/travis/RealTravisEndpointsTest.scala
@@ -2,16 +2,35 @@ package com.atomist.rug.functions.travis
 
 import java.util.Collections
 
-import com.atomist.rug.InvalidRugParameterPatternException
 import org.scalatest.{FlatSpec, Matchers}
 
 class RealTravisEndpointsTest extends FlatSpec with Matchers {
 
-  it should "return cached token" in {
+  "postAuthGithub" should "return cached token" in {
     val t: String = "notarealtravistoken"
     val rte: RealTravisEndpoints = new RealTravisEndpoints
     rte.travisTokens = Collections.singletonMap("doesnotmatter", "notarealtravistoken")
     val api: TravisAPIEndpoint = TravisOrgEndpoint
     assert(rte.postAuthGitHub(api, "doesnotmatter") === t)
+  }
+
+  val rte = new RealTravisEndpoints
+
+  "retry" should "succeed when things succeed" in {
+    val v = rte.retry("test success", 2) { 1 }
+    assert(v === 1)
+  }
+
+  it should "take some time to retry when it fails" in {
+    val startTime = System.currentTimeMillis
+    try {
+      rte.retry("test fail", 4, 10L) {
+        throw new Exception("testing failed retry")
+      }
+    } catch {
+      case _: Exception =>
+    }
+    val endTime = System.currentTimeMillis
+    assert(startTime + 150 < endTime)
   }
 }


### PR DESCRIPTION
Implement retry in a functional way.  We do lose a bit of logic around
the `/users/sync` endpoint, retrying all the time instead of just when
you get a 409/CONFLICT.  The mean time for retrying is 50.65 s.

Update rug dependency.

Add more exception logging.  Silence logging in tests.

Add change log entry for 0.14.1 release.

Closes #7