### PR TITLE
Fix GitHub token scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 -   Retry to all Travis API calls
 -   More exception logging
 
+### Fixed
+
+-   Scopes required by GitHub token
+
 ## [0.14.1] - 2017-05-02
 
 [0.14.1]: https://github.com/atomist/rug-functions-travis/compare/0.14.0...0.14.1

--- a/README.md
+++ b/README.md
@@ -34,6 +34,29 @@ Please see the [Atomist Documentation][docs] for more information.
 
 [docs]: http://docs.atomist.com/
 
+## Authentication
+
+Authenticating against the Travis API requires a GitHub token with
+proper scopes.  The Travis CI public repository (`.org`) and private
+repository (`.com`) endpoints require different scopes.  You can
+always get the current list of scopes for each endpoint directly from
+Travis CI by running the command below, changing `ENDPOINT` to `com`
+for private repositories or `org` for public repositories.
+
+```
+$ curl -s -H 'Content-Type: application/json' -H 'User-Agent: CurlClient/1.0.0' -H 'Accept: application/vnd.travis-ci.2+json' https://api.travis-ci.ENDPOINT/config | jq .config.github.scopes
+```
+
+All of the Travis Rug functions require a GitHub token, accessed
+via [Rug Secrets][secrets], with the "repo", "read:org", and
+"user:email" scopes, which is a union of the scopes required by the
+`.org` and `.com` endpoints.  The token *may* need to be a from a
+GitHub user who is an owner of the repository.  If the owner of the
+repository is a GitHub organization, this means the token must be from
+a user in the Owner group.
+
+[secrets]: http://docs.atomist.com/user-guide/rug/secrets/ (Rug Secrets)
+
 ## Support
 
 General support questions should be discussed in the `#support`

--- a/src/main/scala/com/atomist/rug/functions/travis/BuildRugFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/BuildRugFunction.scala
@@ -22,7 +22,7 @@ class BuildRugFunction
     * @param mavenBaseUrl URL of Maven repository without trailing Slack team ID
     * @param mavenUser user with write access to Maven repository
     * @param mavenToken API token for Maven user
-    * @param userToken GitHub token with "repo" scope for `owner`/`repo`
+    * @param githubToken GitHub token with proper scopes for Travis CI
     * @return Rug function reponse indicating success or failure
     */
   @RugFunction(name = "travis-build-rug", description = "builds a Rug archive on Travis CI using rug-build",
@@ -36,7 +36,7 @@ class BuildRugFunction
             @Secret(name = "mavenBaseUrl", path = "secret://team?path=maven_base_url") mavenBaseUrl: String,
             @Secret(name = "mavenUser", path = "secret://team?path=maven_user") mavenUser: String,
             @Secret(name = "mavenToken", path = "secret://team?path=maven_token") mavenToken: String,
-            @Secret(name = "userToken", path = "github://user_token?scopes=repo") userToken: String): FunctionResponse =
+            @Secret(name = "githubToken", path = TravisFunction.githubTokenPath) githubToken: String): FunctionResponse =
     BuildRug(travisEndpoints).build(owner, repo, version, teamId, gitRef, travisToken, mavenBaseUrl,
-      mavenUser, mavenToken, userToken)
+      mavenUser, mavenToken, githubToken)
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/DisableRepoFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/DisableRepoFunction.scala
@@ -15,7 +15,7 @@ class DisableRepoFunction
     * @param owner GitHub owner, i.e., user or organization, of the repo to enable
     * @param repo name of the repo to disable
     * @param org Travis CI ".com" or ".org" endpoint
-    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @param githubToken GitHub token with proper scopes for Travis CI
     * @return Rug Function Response
     */
   @RugFunction(name = "travis-disable-repo", description = "Disables Travis CI builds for a GitHub repository",
@@ -24,10 +24,10 @@ class DisableRepoFunction
                @Parameter(name = "owner") owner: String,
                @Parameter(name = "repo") repo: String,
                @Parameter(name = "org") org: String,
-               @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
+               @Secret(name = "githubToken", path = TravisFunction.githubTokenPath) githubToken: String
              ): FunctionResponse = {
     val disableTravis = false
-    RepoHook(travisEndpoints).tryRepoHook(disableTravis, owner, repo, token, org)
+    RepoHook(travisEndpoints).tryRepoHook(disableTravis, owner, repo, githubToken, org)
   }
 
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/EnableRepoFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/EnableRepoFunction.scala
@@ -17,7 +17,7 @@ class EnableRepoFunction
     * @param owner GitHub owner, i.e., user or organization, of the repo to enable
     * @param repo name of the repo to enable
     * @param org Travis CI ".com" or ".org" endpoint
-    * @param token GitHub token with "repo" scope for `owner`/`repo`
+    * @param githubToken GitHub token with proper scopes for Travis CI
     * @return Rug FunctionResponse
     */
   @RugFunction(name = "travis-enable-repo", description = "Enables Travis CI builds for a GitHub repository",
@@ -26,10 +26,10 @@ class EnableRepoFunction
               @Parameter(name = "owner") owner: String,
               @Parameter(name = "repo") repo: String,
               @Parameter(name = "org") org: String,
-              @Secret(name = "github_token", path = "github://user_token?scopes=repo") token: String
+              @Secret(name = "githubToken", path = TravisFunction.githubTokenPath) githubToken: String
             ): FunctionResponse = {
     val enableTravis = true
-    RepoHook(travisEndpoints).tryRepoHook(enableTravis, owner, repo, token, org)
+    RepoHook(travisEndpoints).tryRepoHook(enableTravis, owner, repo, githubToken, org)
   }
 
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/EncryptFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/EncryptFunction.scala
@@ -16,7 +16,7 @@ class EncryptFunction
     * @param repo    name of the repo to enable
     * @param org     Travis CI ".com" or ".org" endpoint
     * @param content content to encrypt
-    * @param token   GitHub token with "repo" scope for `owner`/`repo`
+    * @param githubToken   GitHub token with proper scopes for Travis CI
     * @return `content` encrypted using the Travis CI repo public key
     */
   @RugFunction(name = "travis-encrypt", description = "Encrypts a value using Travis CI repo public key",
@@ -25,7 +25,7 @@ class EncryptFunction
               @Parameter(name = "repo") repo: String,
               @Parameter(name = "org") org: String,
               @Parameter(name = "content") content: String,
-              @Secret(name = "user_token", path = "github://user_token?scopes=repo") token: String
-             ): FunctionResponse = Encrypt(travisEndpoints).tryEncrypt(owner, repo, org, content, token)
+              @Secret(name = "githubToken", path = TravisFunction.githubTokenPath) githubToken: String
+             ): FunctionResponse = Encrypt(travisEndpoints).tryEncrypt(owner, repo, org, content, githubToken)
 
 }

--- a/src/main/scala/com/atomist/rug/functions/travis/RestartBuildFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/RestartBuildFunction.scala
@@ -14,14 +14,22 @@ class RestartBuildFunction
     with TravisFunction
     with LazyLogging {
 
+  /**
+    * Restart a presumably failed Travis CI build.
+    *
+    * @param org GitHub organization of build
+    * @param buildId ID of build to restart
+    * @param githubToken GitHub token with proper scopes for Travis CI
+    * @return
+    */
   @RugFunction(name = "restart-travis-build", description = "Restarts a travis build",
     tags = Array(new Tag(name = "travis"), new Tag(name = "ci")))
   def invoke(@Parameter(name = "org") org: String,
              @Parameter(name = "buildId") buildId: Int,
-             @Secret(name = "user_token", path = "github://user_token?scopes=repo") token: String): FunctionResponse = {
+             @Secret(name = "githubToken", path = TravisFunction.githubTokenPath) githubToken: String): FunctionResponse = {
 
       val api: TravisAPIEndpoint = TravisAPIEndpoint.stringToTravisEndpoint(org)
-      val travisToken: String = travisEndpoints.postAuthGitHub(api, token)
+      val travisToken: String = travisEndpoints.postAuthGitHub(api, githubToken)
       val headers: HttpHeaders = TravisEndpoints.authHeaders(travisToken)
       try {
         travisEndpoints.postRestartBuild(api, headers, buildId)
@@ -29,6 +37,7 @@ class RestartBuildFunction
       }
       catch {
         case e: Exception =>
+          logger.error(s"$org build $buildId restart failed: ${e.getMessage}", e)
           FunctionResponse(Status.Failure, Some(s"Failed to restart build `$buildId` on Travis CI"), None, StringBodyOption(e.getMessage))
       }
   }

--- a/src/main/scala/com/atomist/rug/functions/travis/TravisFunction.scala
+++ b/src/main/scala/com/atomist/rug/functions/travis/TravisFunction.scala
@@ -11,3 +11,9 @@ trait TravisFunction extends Rug {
   lazy val travisEndpoints: TravisEndpoints = new RealTravisEndpoints
 
 }
+
+object TravisFunction {
+
+  final val githubTokenPath = "github://user_token?scopes=repo,read:org,user:email"
+
+}


### PR DESCRIPTION
Travis CI requires a GitHub token with more than just the repo scope
so the path for the GitHub token was corrected to include all scopes
required by Travis CI .org and .com endpoints.  Handling of this path
was centralized and parameter naming unified.